### PR TITLE
Update meeting dates to Fridays.

### DIFF
--- a/schedule/README.md
+++ b/schedule/README.md
@@ -1,45 +1,46 @@
 # SSCS Chipathon 2025 Schedule
 
 This document outlines the official schedule for the SSCS Chipathon 2025 event. All dates and activities are subject to confirmation.
+Please follow the [Element Chipathon 2025 channel](https://matrix.to/#/#chipathon-2025:fossi-chat.org) for up-to-date information. 
 
 ## 🗓️ Detailed Timeline
 
 ### Phase 1: Setup and Introduction
 | Week | Date | Event | Track Details | Recording |
 |------|------|-------|---------------|-----------|
-| Week 24 | June 09, 2025 | **Kick-off Meeting** 🎓 | Introduction to chipathon phases (B. Murmann & M. Saligane) | [📼 TBA]() |
-| Week 25 | June 16, 2025 | **Tool Installation** 🎓 | • Full custom (analog) tool chain in docker (Harald)<br>• gLayout additional steps (Saptarshi) | [📼 TBA]() |
-| Week 26 | June 23, 2025 | **Track Overviews** 🎓 | • MOSbius Overview (Peter)<br>• gLayout Tutorial 1 (Saptarshi/Mehdi)<br>• VLSI I + Building Blocks & Flow (Amro, T. Edwards) | [📼 TBA]() |
-| Week 27 | June 30, 2025 | **Tutorial Sessions** 🎓 | • GF180 Examples (Juan)<br>• gLayout Tutorial 2 (Saptarshi/Mehdi/Akira)<br>• VLSI II + Building Blocks & Flow | [📼 TBA]() |
+| Week 24 | June 13, 2025 | **Kick-off Meeting** 🎓 | Introduction to chipathon phases (B. Murmann & M. Saligane) | [📼 TBA]() |
+| Week 25 | June 20, 2025 | **Tool Installation** 🎓 | • Full custom (analog) tool chain in docker (Harald)<br>• gLayout additional steps (Saptarshi) | [📼 TBA]() |
+| Week 26 | June 27, 2025 | **Track Overviews** 🎓 | • MOSbius Overview (Peter)<br>• gLayout Tutorial 1 (Saptarshi/Mehdi)<br>• VLSI I + Building Blocks & Flow (Amro, T. Edwards) | [📼 TBA]() |
+| Week 27 | July 04, 2025 | **Tutorial Sessions** 🎓 | • GF180 Examples (Juan)<br>• gLayout Tutorial 2 (Saptarshi/Mehdi/Akira)<br>• VLSI II + Building Blocks & Flow | [📼 TBA]() |
 
 ### Phase 2: Team Formation and Project Planning
 | Week | Date | Event | Details | Recording |
 |------|------|-------|----------|-----------|
-| - | July 01, 2025 | **Team Formation Deadline** | - | - |
-| Week 28 | July 07, 2025 | **Project Proposal Review** 👥 | - | [📼 TBA]() |
-| Week 29 | July 14, 2025 | **Advanced Topics** 🎓 | • Systematic Design of Analog CMOS Circuits (Boris)<br>• LLM RAG Finetuning & Training (Greg) | [📼 TBA]() |
-| Week 30 | July 21, 2025 | **LLM Integration** 🎓 | • Tutorial: Schematic Database & Simulations (Peter)<br>• Introduction to CACE (Tim E.)<br>• LLM-assisted analog Layout (Saptarshi, Greg, Mehdi)<br>• LLM assisted Digital Flow (Amro, Greg) | [📼 TBA]() |
+| - | July 05, 2025 | **Team Formation Deadline** | - | - |
+| Week 28 | July 11, 2025 | **Project Proposal Review** 👥 | - | [📼 TBA]() |
+| Week 29 | July 18, 2025 | **Advanced Topics** 🎓 | • Systematic Design of Analog CMOS Circuits (Boris)<br>• LLM RAG Finetuning & Training (Greg) | [📼 TBA]() |
+| Week 30 | July 25, 2025 | **LLM Integration** 🎓 | • Tutorial: Schematic Database & Simulations (Peter)<br>• Introduction to CACE (Tim E.)<br>• LLM-assisted analog Layout (Saptarshi, Greg, Mehdi)<br>• LLM assisted Digital Flow (Amro, Greg) | [📼 TBA]() |
 
 ### Phase 3: Design and Simulation
 | Week | Date | Event | Review Focus | Recording |
 |------|------|-------|--------------|-----------|
-| Week 31 | July 28, 2025 | **Schematic Review** 👥 | - | [📼 TBA]() |
-| Week 32 | Aug 04, 2025 | **Simulation Review (blocks)** 👥 | - | [📼 TBA]() |
-| Week 33 | Aug 11, 2025 | **Simulation Review (top level)** 👥 | - | [📼 TBA]() |
-| - | Aug 15, 2025 | **READiness Check & Go/No-go Decision** | - | - |
+| Week 31 | Aug 01, 2025 | **Schematic Review** 👥 | - | [📼 TBA]() |
+| Week 32 | Aug 08, 2025 | **Simulation Review (blocks)** 👥 | - | [📼 TBA]() |
+| Week 33 | Aug 15, 2025 | **Simulation Review (top level)** 👥 | - | [📼 TBA]() |
+| - | Aug 16, 2025 | **READiness Check & Go/No-go Decision** | - | - |
 
 ### Phase 4: Layout and Verification
 | Week | Date | Event | Details | Recording |
 |------|------|-------|----------|-----------|
-| Week 34 | Aug 18, 2025 | **Layout Tutorial** 🎓 | Layout, DRC, LVS, PEX (Mitch, Tim) | [📼 TBA]() |
-| Week 35 | Aug 25, 2025 | **Integration Tutorial** 🎓 | Top level, ESD, padframe, packaging (Juan, Akira) | [📼 TBA]() |
-| Week 36 | Sept 01, 2025 | **Layout Review (blocks)** 👥 | - | [📼 TBA]() |
-| Week 37 | Sept 08, 2025 | **Layout Review (top level)** 👥 | - | [📼 TBA]() |
+| Week 34 | Aug 22, 2025 | **Layout Tutorial** 🎓 | Layout, DRC, LVS, PEX (Mitch, Tim) | [📼 TBA]() |
+| Week 35 | Aug 29, 2025 | **Integration Tutorial** 🎓 | Top level, ESD, padframe, packaging (Juan, Akira) | [📼 TBA]() |
+| Week 36 | Sept 05, 2025 | **Layout Review (blocks)** 👥 | - | [📼 TBA]() |
+| Week 37 | Sept 12, 2025 | **Layout Review (top level)** 👥 | - | [📼 TBA]() |
 | - | Sept 12, 2025 | **DRC Dry-run** | GDS to Channel Partner | - |
-| Week 38 | Sept 15, 2025 | **Verification** 👥 | Simulations w/ PEX + CACE | [📼 TBA]() |
-| Week 39 | Sept 22, 2025 | **Final Chip Review** 👥 | - | [📼 TBA]() |
+| Week 38 | Sept 19, 2025 | **Verification** 👥 | Simulations w/ PEX + CACE | [📼 TBA]() |
+| Week 39 | Sept 26, 2025 | **Final Chip Review** 👥 | - | [📼 TBA]() |
 | - | Sept 26, 2025 | **Final Submission** | DRC-clean GDS to Channel Partner | - |
-| Week 40 | Sept 29, 2025 | **Post-mortem** 👥 | Project retrospective | [📼 TBA]() |
+| Week 40 | Oct 03, 2025 | **Post-mortem** 👥 | Project retrospective | [📼 TBA]() |
 
 ### Phase 5: Manufacturing and Testing
 | Date | Event | Recording |


### PR DESCRIPTION
Included a link to the Element Chipathon 2025 channel.

Note that July 4th falls on a Friday this year. US participation may be limited.

In addition to the meeting dates, I modified the Team formation deadline and Readiness check, but not the Dry-run or final submission dates.