### PR TITLE
Update to the Links in docs landing page 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,9 @@ For the 2025 Chipathon, we will use the open-source GlobalFoundries 180nm (gf180
 
 The following guidelines help you set up the tools using the [IIC-OSIC-TOOLS](https://github.com/iic-jku/iic-osic-tools) Docker image developed by Harald Pretl's team.
 
-**NOTE**: For this Chipathon, it is not required to use the repository for the IIC-OSIC-TOOLS directly, since startup-scripts are provided in [resources/IIC-OSIC-TOOLS](/resources/IIC-OSIC-TOOLS).
+:rotating_light: **NOTE**: For this Chipathon, it is not required to use the repository for the IIC-OSIC-TOOLS directly, since startup-scripts are provided in [resources/IIC-OSIC-TOOLS](/resources/IIC-OSIC-TOOLS).
 
-**NOTE**: For this Chipathon, a special image of the IIC-OSIC-TOOLS is released, with the tag "chipathon". If you use the start-scripts provided here, this tag is used automatically.
+:warning: **NOTE**: For this Chipathon, a special image of the IIC-OSIC-TOOLS is released, with the tag "chipathon". If you use the start-scripts provided here, this tag is used automatically.
 
 Please start with the Quick Start Guide and setup Docker Desktop and the IIC-OSIC-TOOLS. Then, choose one of the following tutorial links to set up the tools, which best fits your environment. Experienced users may configure the tools using their own preferred approach.
 

--- a/resources/Analog_Automation_gLayout/README.md
+++ b/resources/Analog_Automation_gLayout/README.md
@@ -1,24 +1,17 @@
 # gLayout Track Resources
 
-> 🚧 **Under Construction**
-
 - [Brief Overview of the gLayout](./files/gLayout_Overview.pdf)
-
-- [GitHub Repo](https://github.com/ReaLLMASIC/gLayout)
-- [Getting Started](https://docs.google.com/document/d/e/2PACX-1vT1jADYn6HAjlp1b3KB7T0nAkxzmT5GXo7NzFjxZ47M9s9H3oyHdoU39wxUscF8DtTNeQ3Egeo_1e1s/pub)
-
+- 🤖 [GitHub Repo](https://github.com/ReaLLMASIC/gLayout)
+- :eyes: [Getting Started](https://docs.google.com/document/d/e/2PACX-1vT1jADYn6HAjlp1b3KB7T0nAkxzmT5GXo7NzFjxZ47M9s9H3oyHdoU39wxUscF8DtTNeQ3Egeo_1e1s/pub)
   - [IIC-OSIC Docker Image setup](../IIC-OSIC-TOOLS/README.md)
   - [gLayout Specific Setup](./files/gLayout_Install.md)
-
-- :new: Design Challenge 1
-  - [Detailed Requirements](./Challenge.md)
-  - [Kickoff Slides](https://docs.google.com/presentation/d/11iUuCnZQZhC-76pMEIqsWOjoYRWxP6tA/edit?slide=id.g369dd00d293_0_563#slide=id.g369dd00d293_0_563)
-  
-- :new: [gLayout Tutorials](https://github.com/ReaLLMASIC/gLayout/tree/main/tutorial)
+- :books: [gLayout Tutorials](https://github.com/ReaLLMASIC/gLayout/tree/main/tutorial)
   - [Flipped Voltage Follower (FVF)](https://github.com/ReaLLMASIC/gLayout/blob/main/tutorial/glayout_tutorial_FVF_part1.ipynb)
   - [Inverter (INV)](https://github.com/ReaLLMASIC/gLayout/blob/main/tutorial/glayout_tutorial_INV_part1.ipynb)
-
-- [Contribution Guidelines](https://docs.google.com/presentation/d/e/2PACX-1vRYHpcxItcbHfINOcBYVJ0q8JRr79yXTh8uxrhY4bHtAs3voaiZQN49snRvW8E6vg/pub?slide=id.g36c8198f0d5_0_37)
+- :pushpin: Design Challenge
+  - [Detailed Requirements](./Challenge.md)
+  - [Kickoff Slides](https://docs.google.com/presentation/d/11iUuCnZQZhC-76pMEIqsWOjoYRWxP6tA/edit?slide=id.g369dd00d293_0_563#slide=id.g369dd00d293_0_563)
+- 🦾 [Contribution Guidelines](https://docs.google.com/presentation/d/e/2PACX-1vRYHpcxItcbHfINOcBYVJ0q8JRr79yXTh8uxrhY4bHtAs3voaiZQN49snRvW8E6vg/pub?slide=id.g36c8198f0d5_0_37)
   - [Fork the gLayout Repo]() 
   - [Contribute]()
   - [Create Merge Request]()


### PR DESCRIPTION
In response to Issue #37 and other participant feedback, all links in the docs landing page are updated to official setup instructions linked to the sscs-chipathon-2025 repository.

Minor Changes
- Links updated in the gLayout Repo with new Tutorials
- A few Emojis added to highly important instructions